### PR TITLE
abstracted future and past appointment lists into includable template

### DIFF
--- a/templates/interviews/appointment_list.html
+++ b/templates/interviews/appointment_list.html
@@ -1,0 +1,18 @@
+  <div class="card">
+	<div class="card-block">
+		<h2 class="card-title">{{title}} Termine:</h2>
+		<div class="card-text">
+		  <ul>
+		    {% for apt in apts %}
+		      <li>
+		        <strong>{{apt.datetime|date:"l, j. F Y"}} um {{apt.datetime|time:"TIME_FORMAT"}}: <a href="{% url 'show_application' apt.application.id %}">{{apt.application.first_name}} {{apt.application.last_name}} ({{apt.application.gender}}) für {{apt.application.country}}</a></strong>, {{apt.interview_lead.get_full_name|default:apt.interview_lead.username}} &amp; {{apt.interview_snd.get_full_name|default:apt.interview_snd.username}}: <a href="{{apt.link}}">{{apt.link}}</a>
+		      </li>
+		    {% empty %}
+		      <div class="alert alert-default" role="alert">
+		      Keine {{none}}n Termine
+		      </div>
+		    {% endfor %}
+		  </ul>
+		</div>
+	  </div>
+  </div>

--- a/templates/interviews/my_appointments.html
+++ b/templates/interviews/my_appointments.html
@@ -2,44 +2,8 @@
 
 {% block content %}
 <div class="container">
-  <div class="card">
-	<div class="card-block">
-		<h2 class="card-title">Nächste Termine:</h2>
-		<div class="card-text">
-		  <ul>
-		    {% for apt in upcoming.all %}
-		      <li>
-		        <strong>{{apt.datetime|date:"l, j. F Y"}} um {{apt.datetime|time:"TIME_FORMAT"}}: <a href="{% url 'show_application' apt.application.id %}">{{apt.application.first_name}} {{apt.application.last_name}} ({{apt.application.gender}}) für {{apt.application.country}}</a></strong>, {{apt.interview_lead.get_full_name|default:apt.interview_lead.username}} &amp; {{apt.interview_snd.get_full_name|default:apt.interview_snd.username}}: <a href="{{apt.link}}">{{apt.link}}</a>
-		      </li>
-		    {% empty %}
-		      <div class="alert alert-default" role="alert">
-		      Keine kommenden Termine
-		      </div>
-		    {% endfor %}
-		  </ul>
-		</div>
-	  </div>
-  </div>
-
+  {% include "interviews/appointment_list.html" with title="Nächste" none="kommende" apts=upcoming.all %}
   <br />	
-
-  <div class="card">
-	<div class="card-block">
-		<h3 class="card-title">vergangene Termine</h3>
-		<div class="card-text">
-		  <ul>
-		    {% for apt in past.all %}
-		      <li>
-		        <strong>{{apt.datetime|date:"l, j. F Y"}} um {{apt.datetime|time:"TIME_FORMAT"}}: {{apt.name}} ({{apt.email}})</strong>, {{apt.interview_lead.name}} &amp; {{apt.interview_snd.name}}: <a href="{{apt.link}}">{{apt.link}}</a>
-		      </li>
-		    {% empty %}
-		      <div class="alert alert-default" role="alert">
-		      Keine bisherigen Termine
-		      </div>
-		    {% endfor %}
-		  </ul>
-		 </div>
-	   </div>
-	</div>
+  {% include "interviews/appointment_list.html" with title="Vergangene" none="bisherige" apts=past.all %}
  </div>
 {% endblock %}


### PR DESCRIPTION
The future appointment list should display unchanged; the past appointment list should now display like the future appointment list.

fixes #24