### PR TITLE
urgent change requested by Clemens: ethical dilemma

### DIFF
--- a/appntr/views.py
+++ b/appntr/views.py
@@ -262,7 +262,7 @@ class ApplicationForm(ModelForm):
                                  label="Welche Fähigkeiten, Erfahrungen und Ideen willst Du als Mitglied einbringen, die DiB nach vorne bringen werden?",
                                  widget=forms.Textarea)
     ethical_dilemma = forms.CharField(validators=[min_length],
-                                 label="Was würdest Du tun, wenn die Beweger/innen und Mitglieder von Demokratie in Bewegung nach dem Initiativprinzip eine Programmentscheidung herbeiführen, die Du persönlich nicht unterstützt?",
+                                 label="Was würdest Du tun, wenn basisdemokratisch (nach dem Initiativprinzip) eine inhaltliche Entscheidung getroffen wird, die Du persönlich nicht unterstützt?",
                                  widget=forms.Textarea)
 
     diversity = forms.BooleanField(required=True,


### PR DESCRIPTION
Clemens urgently requested a change in the wording of the ethical dilemma question because he wants to send out a newsletter that might reach a lot of people and he's worried that the current formulation might deter people. Guido as the coordinator of the membership team and Alex as a BuVo member signed off on the change.