### PR TITLE
Copy requirements makes this cachable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM python:3
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
-ADD . /code
+ADD requirements.txt /code
 RUN pip install -r requirements.txt
+ADD . /code


### PR DESCRIPTION
Increases deploy time, as docker caches the image at every step and thus the requirements are only polled again if that has changed. Otherwise it only deploys the new code base rather than all dependencies.